### PR TITLE
Improve resilience when Chart.js is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lista de la compra
 
-Aplicación web básica para gestionar una lista de la compra con HTML, CSS y JavaScript. Incluye almacenamiento en `localStorage` y una gráfica con Chart.js.
+Aplicación web básica para gestionar una lista de la compra con HTML, CSS y JavaScript. Incluye almacenamiento en `localStorage` y una gráfica opcional con Chart.js. Si la librería no está disponible (por ejemplo, sin conexión), la aplicación sigue funcionando sin la gráfica.
 
 ## Estructura
 - `src/index.html` – página principal

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -8,7 +8,13 @@ const STORAGE_KEY = 'shopping_list_v1';
 function loadData() {
     const data = localStorage.getItem(STORAGE_KEY);
     if (data) {
-        items = JSON.parse(data);
+        try {
+            items = JSON.parse(data);
+        } catch (e) {
+            console.error('Error parsing stored data', e);
+            items = [];
+            saveData();
+        }
     }
 }
 
@@ -92,6 +98,10 @@ function clearList() {
 
 // Actualizar gráfica
 function updateChart() {
+    if (typeof Chart === 'undefined') {
+        return;
+    }
+
     const dataMap = {};
     items.forEach(item => {
         if (!dataMap[item.name]) {


### PR DESCRIPTION
## Summary
- guard JSON parsing errors when loading data
- allow app to work without Chart.js
- clarify Chart.js is optional in README

## Testing
- `node --check src/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_684d4e48ed908321b5246e7b38c59df3